### PR TITLE
some keyboards dont emit all three midi values

### DIFF
--- a/value.js
+++ b/value.js
@@ -34,8 +34,14 @@ function midiValue(duplexPort, mapping, output){
 
   function handleData(data){
     var key = data[0] + '/' + data[1]
+    var value = data[2]
+    // on some keyboards, there are not three values, only a two value
+    if (data[2] === undefined) {
+      key = data[0].toString()
+      value = data[1]
+    }
     if (mapping == key){
-      obs.set(data[2])
+      obs.set(value)
     }
   }
 


### PR DESCRIPTION
This fixes some keyboards that dont emit all three midi values.

I know there should be other similar fixes for array, grid, etc, but this gets me through a wall for now. I will patch those as needed. 

