### PR TITLE
2 values midi actually have an undefined 3rd array member.

### DIFF
--- a/lib/get-mapped-message.js
+++ b/lib/get-mapped-message.js
@@ -1,16 +1,23 @@
 module.exports = function (data) {
-  if (data) {
-    if (data.length === 3) {
-      return {
-        key: data[0] + '/' + data[1],
-        value: data[2]
+  if (data && data.length) {
+    var keys = []
+    var value = null
+
+    if (typeof data[0] !== 'undefined') {
+      keys.push(data[0])
+      value = data[1]
+    }
+    if (typeof data[1] !== 'undefined') {
+      if (typeof data[2] !== 'undefined') {
+        keys.push(data[1])
+        value = data[2]
+      } else {
+        value = data[1]
       }
-    } else if (data.length === 2) {
-      // handle condition where some devices only output two midi values
-      return {
-        key: String(data[0]),
-        value: data[1]
-      }
+    }
+    return {
+      key: keys.join('/'),
+      value: value
     }
   } else {
     // weird, how did this happen?

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ test('value', function(t){
 
 })
 
-test.only('value - 2 value midi', function(t){
+test('value - 2 value midi', function(t){
 
   var output = []
   var duplexPort = Through(function(data){
@@ -52,9 +52,9 @@ test.only('value - 2 value midi', function(t){
     changes.push(value)
   })
 
-  duplexPort.queue([123, 100])
-  duplexPort.queue([123, 70])
-  duplexPort.queue([123, 0])
+  duplexPort.queue([123, 100, undefined])
+  duplexPort.queue([123, 70, undefined])
+  duplexPort.queue([123, 0, undefined])
 
   obs.output.set([0, 127]) // value stack: top most outputted
   obs.output.set(50)
@@ -73,6 +73,29 @@ test.only('value - 2 value midi', function(t){
 
   t.end()
 })
+
+test('value - 1 value midi', function(t){
+
+  var output = []
+  var duplexPort = Through(function(data){
+    output.push(data)
+  })
+
+  var obs = ObservMidi(duplexPort, '123')
+  var changes = []
+  obs(function(value){
+    changes.push(value)
+  })
+
+  duplexPort.queue([123, undefined, undefined])
+
+  t.same(changes, [
+    undefined
+  ])
+
+  t.end()
+})
+
 
 test('varhash', function(t){
 


### PR DESCRIPTION
 Also work with 1 value midi

I checked the work done with the two value midi and it was not quite correct. checking for the length of the array was inaccurate, because the the array was actually [208, 74, undefined]. 

Also for lols my controller has a button that emits a [252] and thats it. 

This merge request fixes both cases, and I added a test for the 1 value midi.

If you could be so kind if merged to bump version and push. Thanks!